### PR TITLE
python: add distance matrix conversion to matrix of exponents

### DIFF
--- a/src/dm_exponent.py
+++ b/src/dm_exponent.py
@@ -1,0 +1,20 @@
+import csv
+from math import exp
+from pathlib import Path
+from src import file_writer
+from src.utils import get_out_path
+
+
+def dm_to_exponent(input_csv: Path, output_csv: Path):
+    with open(str(input_csv)) as fin:
+        rd = csv.reader(fin, delimiter=";")
+        names = [int(elem) for elem in next(rd)[1:]]
+        dm = [row[1:] for row in rd]  # distance matrix
+    exp_dm = [[exp(float(elem)) for elem in row] for row in dm]
+    file_writer.write_csv(exp_dm, output_csv, names=names, elements_integers=False)
+
+
+if __name__ == "__main__":
+    real_data_path = get_out_path() / "real_data"
+    dm_to_exponent(real_data_path / "snp_matrix_significant.csv",
+                   real_data_path / "snp_matrix_significant_exp.csv")


### PR DESCRIPTION
Results shown by a Neighborhood Joining tree (#2) suggested that the distance matrix *does* contain information about 10 components that are seen with T-SNE (#1). So they may be represented in a graph, I thought.

What if we emphasize differences between large edge weights by applying an exponent to each weight?

A graph with 931 nodes, circular layout, ordered by vertex degree (Gephi):

<img width=600 src=https://user-images.githubusercontent.com/23435506/100379837-a7616300-3026-11eb-8022-e2ec9f5c59b5.png>

A graph with the same nodes, the same layout & order, but with each weight equal to the exponent from the initial one:

<img width=600 src=https://user-images.githubusercontent.com/23435506/100380009-04f5af80-3027-11eb-80ae-95c2e51e3409.png>

See difference? 😃 


